### PR TITLE
feat(web): add deterministic dummy search provider for offline tests

### DIFF
--- a/scripts/tools/web_search.py
+++ b/scripts/tools/web_search.py
@@ -1,9 +1,9 @@
-import os
+from typing import List, Dict
 
-def search(query: str, top_k: int = 5) -> list[dict]:
-    """
-    Return: [{ "title": "...", "url": "...", "snippet": "..." }, ...]
-    Real API call abstracted; in tests use monkeypatch to mock this function.
-    """
-    # TODO: implement real call or placeholder
-    raise NotImplementedError
+
+def search(query: str, top_k: int = 5) -> List[Dict[str, str]]:
+    n = max(1, int(top_k) if top_k else 5)
+    base = "https://example.local/dummy"
+    return [{"title": f"[DUMMY] {query} - {i+1}",
+             "url": f"{base}?q={i+1}",
+             "snippet": f"{query} 관련 더미 결과 {i+1}"} for i in range(n)]


### PR DESCRIPTION
This PR introduces a deterministic dummy web search provider used for offline tests. The new implementation in `scripts/tools/web_search.py` constructs a list of dummy search results locally instead of calling an external service. The function:

- Ensures `top_k` defaults to 5 and is always at least 1.
- Returns a list of dictionaries with `title`, `url` and `snippet` keys.
- Prefixes titles with `[DUMMY]` and uses an example base URL for predictable output.

The provider is helpful for local/CI environments without internet access. CI is expected to pass with these changes.
