### PR TITLE
chore(guard): add pre-commit secret/project blockers and enable hooksPath

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,5 @@
 #!/bin/bash
+# Run pre-commit secret/project guard
+python scripts/hooks/precommit_secrets_guard.py || exit $?
+# Run existing no-delete guard
 python scripts/check_no_delete.py

--- a/scripts/hooks/precommit_secrets_guard.py
+++ b/scripts/hooks/precommit_secrets_guard.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+
+def main():
+    # get list of staged files from git
+    result = subprocess.run(["git", "diff", "--cached", "--name-only"], capture_output=True, text=True)
+    if result.returncode != 0:
+        print("pre-commit guard: failed to list staged files", file=sys.stderr)
+        sys.exit(result.returncode)
+
+    files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
+    blocked_patterns = [
+        re.compile(r"^projects/"),
+        re.compile(r"^\.gemini/.*(oauth|creds|token|secret)", re.IGNORECASE),
+        re.compile(r"^\.gemini/.*\.(json|db|sqlite|pem|p12|key)$", re.IGNORECASE),
+    ]
+
+    violations = []
+    for f in files:
+        for pattern in blocked_patterns:
+            if pattern.search(f):
+                violations.append(f)
+                break
+
+    if violations:
+        print("\U0001f6d1 Commit blocked by pre-commit guard. The following files are disallowed:", file=sys.stderr)
+        for path in violations:
+            print(f" - {path}", file=sys.stderr)
+        print("\nRemove these files from the commit or adjust .gitignore before committing.", file=sys.stderr)
+        sys.exit(1)
+
+    # no violations
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose
Add a pre-commit hook to prevent commits of sensitive files and the `projects/` directory. The new Python guard scans staged files for disallowed patterns such as `.gemini/*(oauth|creds|token|secret|json|db|sqlite|pem|p12|key)` and any file under `projects/`. If a match is found, the hook aborts the commit.

## Changes
- Added `scripts/hooks/precommit_secrets_guard.py` implementing the guard logic.
- Updated `.githooks/pre-commit` to run the guard script prior to existing `check_no_delete.py` checks.
- Repository already sets `core.hooksPath=.githooks` so the hook is active.

## Testing
Due to environment limitations, full CI runs aren't available here. I verified the guard script manually by staging files matching disallowed patterns and confirming the hook blocked the commit.
